### PR TITLE
Fix ISBN.from_string to ignore positioning of hyphens

### DIFF
--- a/lib/isbn.rb
+++ b/lib/isbn.rb
@@ -83,7 +83,7 @@ module ISBN
   end
   
   def from_string(source)
-    regex = /(?:ISBN[- ]*13|ISBN[- ]*10|)\s*((?:(?:97[89])?[ -]?(?:[0-9][ -]*){9})[ -]*(?:[0-9xX]))/
+    regex = /(?:ISBN[- ]*13|ISBN[- ]*10|)\s*((?:(?:9[\s-]*7[\s-]*[89])?[ -]?(?:[0-9][ -]*){9})[ -]*(?:[0-9xX]))/
     match = source.scan(regex).flatten
     match.map! { |i| i.gsub(/[\s-]+/, "-") }
     match = match.find {|i| ISBN.valid?(i) }

--- a/test/isbn_spec.rb
+++ b/test/isbn_spec.rb
@@ -74,6 +74,7 @@ describe ISBN do
   end
   
   it "should get isbn from source string" do
+    ISBN.from_string("ISBN:9-7883-7659-303-6\nmore of content").must_equal "9-7883-7659-303-6"
     ISBN.from_string("ISBN:978-83-7659-303-6\nmore of content").must_equal "978-83-7659-303-6"
     ISBN.from_string("ISBN-13 978-3-540-49698-4 and more content").must_equal "978-3-540-49698-4"
     ISBN.from_string("ISBN-10 3-921099-34-X and more content").must_equal "3-921099-34-X"


### PR DESCRIPTION
Ignore positioning of spaces or hyphens in a ISBN-13.
Fixes issue: https://github.com/tkersey/isbn/issues/11