### PR TITLE
Bugfix/encoding binary error

### DIFF
--- a/lib/isbn.rb
+++ b/lib/isbn.rb
@@ -76,6 +76,7 @@ module ISBN
     require "open-uri"
     require "tempfile"
     tmp = Tempfile.new("tmp")
+    tmp.binmode
     tmp.write(open(url, "rb:binary").read)
     tmp.close
     isbn = %x{djpeg -pnm #{tmp.path} | gocr -}

--- a/test/isbn_spec.rb
+++ b/test/isbn_spec.rb
@@ -89,4 +89,8 @@ describe ISBN do
   it "should add dashes to isbn 10 without dashes" do
     ISBN.with_dashes("0763740382").must_equal "0-7637-4038-2"
   end
+
+  it "should scan a isbn from image" do
+    ISBN.from_image("http://barcodesaustralia.com/wp-content/uploads/2011/07/sample-isbn-jpg.jpg").must_equal eq "9781234567897"
+  end
 end


### PR DESCRIPTION
Using this gem I got this issue:

`Encoding::UndefinedConversionError ("\x89" from ASCII-8BIT to UTF-8)`

Then looking around I found that `Tempfile` should be open in binary mode

I added `temp.binmode` and also added a test to from_image method 😄.

Thank you very much for this gem, it was really useful for me! 👍 